### PR TITLE
fix: allow generic string in string reference

### DIFF
--- a/spasm/asm.py
+++ b/spasm/asm.py
@@ -153,7 +153,7 @@ class Assembly:
         if not text.startswith("$"):
             return None
 
-        return self._parse_ident(text[1:])
+        return text[1:]
 
     def _parse_try_begin(self, line: str) -> t.Optional[bc.TryBegin]:
         try:


### PR DESCRIPTION
Some opcodes might requre strings that are not necessarily an identifier. We allow for arbitrary string references in opcode arguments.