### PR TITLE
feat: in-source spasm decorator and bytecode inliner 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Supports CPython 3.10 through 3.14, and has no runtime dependencies.
 - [Installation](#installation)
 - [Usage](#usage)
 - [Examples](#examples)
+- [In-source assembly](#in-source-assembly)
+- [Bytecode inlining](#bytecode-inlining)
 - [Build backend](#build-backend)
 - [Low-level API](#low-level-api)
 - [Architecture](#architecture)
@@ -202,6 +204,126 @@ CPython 3.11 a captured parameter occupies a single frame slot that is at once
 a local and a cell, and `MAKE_CELL` is what turns it into one. `inner` is
 reachable only from `outer`, since a nested block is a constant of the block it
 is written in and not of the module.
+
+
+## In-source assembly
+
+Writing assembly in its own `.pya` file works well for a whole module, but
+sometimes only one function needs to drop to bytecode and the rest of the
+file is ordinary Python. `spasm.asm` lets that function keep its assembly
+right where it is defined, in its own docstring:
+
+```python
+import spasm
+
+@spasm.asm(retval=42)
+def answer():
+    """
+    resume 0
+    load_const {retval}
+    return_value
+    """
+
+assert answer() == 42
+```
+
+At decoration time, `asm` parses the docstring as assembly (through the same
+`Assembly` the `spasm` CLI and `.pya` files use), compiles it, replaces
+`answer.__code__` with the result, and clears `__doc__` — it held source, not
+documentation.
+
+This one has two different, easily-confused kinds of "argument", so it's
+worth spelling out which is which:
+
+| | Resolved when | Reaches the assembly as |
+| --- | --- | --- |
+| `answer`'s own parameters (`def add(x, y):`) | Every call, from the caller's arguments | `load_fast`/`store_fast` on the parameter name, exactly as in a nested `code` block in a `.pya` file |
+| The decorator's keyword arguments (`retval=42` above) | Once, when `@spasm.asm(...)` runs | `{name}` placeholders in the docstring, substituted before it's assembled |
+
+The first is what `def add(x, y): ...` already means in Python — nothing
+`asm`-specific about it. The second is `Assembly.compile()`'s existing
+bind-args mechanism (the same one `.pya` files use), exposed here so the
+docstring can embed a compile-time constant without hardcoding it. It's easy
+to reach for the decorator's keyword arguments out of habit and expect them
+to behave like a call's arguments; they don't — they're baked into the
+compiled bytecode once, not read fresh from a call:
+
+```python
+@spasm.asm()
+def add(x, y):
+    """
+    resume 0
+    load_fast $x
+    load_fast $y
+    binary_op 0
+    return_value
+    """
+
+assert add(3, 4) == 7
+```
+
+`add`'s parameters (`x`, `y`) come straight from its own `def` line, so
+there's no `code NAME(args)` header to write. There is also no closure
+support: `*args`, `**kwargs`, keyword-only arguments and free/cell variables
+all raise `ValueError` at decoration time. A function that needs any of
+those still has the nested `code` block syntax available in a `.pya` file.
+
+
+## Bytecode inlining
+
+`spasm.inline` is a decorator for the *caller*, not the callee. A
+callee-side decorator would need to find and rewrite every call site across
+the codebase that happens to call it — other modules, other decorators
+already applied to those callers, code not even loaded yet — which is not
+something a decorator running once at callee-definition time can do.
+Decorating the caller sidesteps that entirely: the caller already knows
+which call sites are its own, so `inline` only ever rewrites the one code
+object it's attached to. It needs no cooperation from the function being
+inlined, only proof — checked structurally against the callee's own
+`__code__` — that inlining it is safe:
+
+```python
+import dis
+import spasm
+
+def add_one(x):
+    return x + 1
+
+@spasm.inline
+def compute(n):
+    return add_one(n) * 2
+
+assert compute(5) == 12
+assert not any(instr.opname.startswith("CALL") for instr in dis.get_instructions(compute))
+```
+
+At decoration time, it walks `compute`'s bytecode for call sites shaped like
+a module-level function call with a fixed number of simple positional
+arguments (`LOAD_GLOBAL` + plain `LOAD_FAST`/`LOAD_CONST` pushes + `CALL`),
+resolves the name against `compute.__globals__`, and checks the callee's own
+`__code__` for anything that would make splicing it in unsafe: a generator or
+coroutine, `*args`/`**kwargs`, a closure, an exception table, or a call to
+itself. Anything it can prove safe gets its body spliced directly into the
+caller in place of the call, with every `return` becoming a jump to a shared
+point after the splice. Anything it can't — a keyword argument, a starred
+call, a generator callee — is left exactly as it was, so `inline` is a pure
+optimization: it never changes what a caller returns, only whether it still
+contains a `CALL`.
+
+A parameter the callee never reassigns, pushed by a single `LOAD_FAST` or
+`LOAD_CONST` in the caller, is substituted directly at each of its use sites
+instead of round-tripping through a dedicated local — so `add_one`'s `x`
+above becomes `n` directly rather than a copy of it. Only a callee-local
+variable computed inside the callee's own body still needs a slot of its own
+in the caller.
+
+On a tight loop calling a several-line function once per iteration, this
+typically shaves 10–15% off the loop's running time — call overhead is a
+meaningful fraction of a small function's cost, but not the only cost, so
+`inline` narrows that gap rather than closing it. Functions with only a
+handful of call sites, called rarely, will not see a measurable difference,
+and that's fine: `inline` returns a caller unchanged when it finds nothing
+worth splicing.
 
 
 ## Build backend
@@ -497,8 +619,11 @@ wheel per Python minor version rather than a single abi3 wheel.
 `spasm.bytecode` is a thin Python layer over it holding the parts that are
 version-dependent bookkeeping rather than data structure: the `Compare` and
 `BinaryOp` symbolic opargs and their per-version encodings, name-argument
-packing for `LOAD_GLOBAL`/`LOAD_ATTR`, and `co_flags` inference. `spasm.asm`
-builds on both and stays concerned with parsing and assembly.
+packing for `LOAD_GLOBAL`/`LOAD_ATTR`, and `co_flags` inference. `spasm._asm`
+builds on both and stays concerned with parsing and assembly; its `Assembly`
+class is re-exported as `spasm.Assembly` (and driven, for the docstring-based
+form, by the `spasm.asm` decorator) so nothing outside this package needs to
+import the private module directly.
 
 Stack depth (`co_stacksize`) is computed for you. Exception table entry depths
 are inferred too, but only where that can be done exactly — see the note in

--- a/spasm/__init__.py
+++ b/spasm/__init__.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
-from spasm.asm import Assembly
+from spasm._asm import Assembly
+from spasm.decorators import asm
+from spasm.inliner import inline
 
-__all__ = ["Assembly"]
+__all__ = ["Assembly", "asm", "inline"]

--- a/spasm/__main__.py
+++ b/spasm/__main__.py
@@ -4,6 +4,8 @@ from argparse import ArgumentParser
 from pathlib import Path
 from types import CodeType
 
+from spasm._asm import Assembly
+from spasm._asm import OpArg
 from spasm._pyc import PycUnmarshalError
 from spasm._pyc import PycWriteError
 from spasm._pyc import write_pyc
@@ -12,8 +14,6 @@ from spasm._pyc import write_pyc
 # from a fresh checkout; the ignore keeps mypy quiet there. It reads as unused
 # once the package has been built at least once.
 from spasm._version import __version__  # type: ignore[import]
-from spasm.asm import Assembly
-from spasm.asm import OpArg
 from spasm.bytecode import UNSET
 
 

--- a/spasm/_asm.py
+++ b/spasm/_asm.py
@@ -163,6 +163,9 @@ class Assembly:
         *,
         is_function: bool = False,
         is_nested: bool = False,
+        argnames: list[str] | None = None,
+        cellvars: list[str] | None = None,
+        freevars: list[str] | None = None,
     ) -> None:
         # Labels and protected regions are positions into the instruction
         # list, not entries in it, which is how the core models them too.
@@ -177,13 +180,13 @@ class Assembly:
         self._lineno = lineno
         self._is_function = is_function
         self._is_nested = is_nested
-        self._argnames: list[str] = []
+        self._argnames: list[str] = argnames or []
         # Variables this code object closes over: cells are locals captured by
         # a nested block, frees are captured from the enclosing one. Declared
         # in the block header rather than inferred, since nothing in the
         # instruction stream distinguishes the two.
-        self._cellvars: list[str] = []
-        self._freevars: list[str] = []
+        self._cellvars: list[str] = cellvars or []
+        self._freevars: list[str] = freevars or []
         self._bind_opargs: dict[int, BindOpArg] = {}
         self._codes: dict[str, Assembly] = {}
         self._code_refs: dict[int, CodeRefOpArg] = {}

--- a/spasm/buildbackend.py
+++ b/spasm/buildbackend.py
@@ -30,8 +30,8 @@ from pathlib import Path
 from types import CodeType
 from types import ModuleType
 
+from spasm._asm import Assembly
 from spasm._pyc import code_to_pyc_bytes
-from spasm.asm import Assembly
 
 try:
     import tomllib  # type: ignore[import-not-found]

--- a/spasm/bytecode.py
+++ b/spasm/bytecode.py
@@ -15,7 +15,7 @@ structure:
   built from scratch,
 * :data:`UNSET`, the "this instruction takes no argument" sentinel.
 
-Keeping these here rather than in :mod:`spasm.asm` means anything building on
+Keeping these here rather than in :mod:`spasm._asm` means anything building on
 the core gets them, and the assembler stays about assembly.
 """
 
@@ -39,6 +39,7 @@ __all__ = [
     "Instr",
     "Label",
     "compare_oparg",
+    "decode_name_arg",
     "encode_name_arg",
     "infer_flags",
 ]
@@ -201,6 +202,13 @@ def encode_name_arg(code: Bytecode, opname: str, name: str, *, flag: bool = Fals
     if (opname == "LOAD_GLOBAL" and PY311) or (opname == "LOAD_ATTR" and PY312):
         return (index << 1) | int(bool(flag))
     return index
+
+
+def decode_name_arg(names: t.Sequence[str], opname: str, arg: int) -> tuple[str, bool]:
+    """Inverse of :func:`encode_name_arg`: unpack a name and its flag bit from an oparg."""
+    if (opname == "LOAD_GLOBAL" and PY311) or (opname == "LOAD_ATTR" and PY312):
+        return names[arg >> 1], bool(arg & 1)
+    return names[arg], False
 
 
 # ---------------------------------------------------------------------------

--- a/spasm/decorators.py
+++ b/spasm/decorators.py
@@ -1,0 +1,81 @@
+"""Writing spasm assembly directly inside a Python source file.
+
+:func:`asm` replaces a decorated function's body with the assembly written in
+its own docstring, compiled through the same :class:`spasm.Assembly` the
+``spasm`` CLI and file-based ``.pya`` sources already use::
+
+    import spasm
+
+    @spasm.asm(retval=42)
+    def answer():
+        \"\"\"
+        load_const {retval}
+        return_value
+        \"\"\"
+
+The decorator's own keyword arguments are assembler bind-args (``{name}``
+placeholders in the docstring, see :meth:`Assembly.compile`), resolved once
+at decoration time — not the function's runtime parameters. Those come from
+the function's own signature, same as any other ``def``, and are reached
+from the assembly with ``load_fast``/``store_fast`` exactly as in a nested
+``code`` block in a ``.pya`` file.
+"""
+
+import typing as t
+
+from spasm._asm import Assembly
+from spasm.bytecode import CO_VARARGS
+from spasm.bytecode import CO_VARKEYWORDS
+
+__all__ = ["asm"]
+
+_F = t.TypeVar("_F", bound=t.Callable[..., t.Any])
+
+
+def asm(**bind_args: t.Any) -> t.Callable[[_F], _F]:
+    """Compile a decorated function's docstring as spasm assembly.
+
+    ``bind_args`` are compile-time bind-args substituted into ``{name}``
+    placeholders in the docstring before it's assembled — not the function's
+    runtime parameters, which are taken from ``func.__code__`` rather than a
+    textual ``code NAME(args)`` header, since the decorator already knows
+    them. ``*args``/``**kwargs``, keyword-only arguments and closures
+    (cellvars/freevars) aren't supported: write those with the nested
+    ``code`` block syntax in a ``.pya`` file instead.
+    """
+
+    def decorator(func: _F) -> _F:
+        code = func.__code__
+        qualname = func.__qualname__
+
+        if func.__doc__ is None:
+            msg = f"{qualname}: asm requires a docstring containing the assembly"
+            raise ValueError(msg)
+
+        if code.co_flags & (CO_VARARGS | CO_VARKEYWORDS):
+            msg = f"{qualname}: asm does not support *args or **kwargs"
+            raise ValueError(msg)
+
+        if code.co_kwonlyargcount:
+            msg = f"{qualname}: asm does not support keyword-only arguments"
+            raise ValueError(msg)
+
+        if code.co_freevars or code.co_cellvars:
+            msg = f"{qualname}: asm does not support closures"
+            raise ValueError(msg)
+
+        assembly = Assembly(
+            name=qualname,
+            filename=code.co_filename,
+            lineno=code.co_firstlineno,
+            is_function=True,
+            argnames=list(code.co_varnames[: code.co_argcount]),
+        )
+        assembly.parse(func.__doc__)
+
+        func.__code__ = assembly.compile(bind_args, lineno=code.co_firstlineno)  # type: ignore[misc]
+        func.__doc__ = None
+
+        return func
+
+    return decorator

--- a/spasm/inliner.py
+++ b/spasm/inliner.py
@@ -1,0 +1,400 @@
+"""Splicing eligible callees directly into a caller's bytecode.
+
+:func:`inline` is a decorator applied to the *caller*. It looks for
+``LOAD_GLOBAL``-resolved calls with a fixed number of simple positional
+arguments (plain ``LOAD_FAST``/``LOAD_CONST`` pushes, nothing computed
+through a nested call or attribute access), and where the resolved callee is
+a plain function it can prove safe to inline — no generator/coroutine, no
+``*args``/``**kwargs``, no closure, no exception table, and an exact arg
+count match — it splices the callee's body directly into the caller in place
+of the call. Anything it can't prove safe is left exactly as it was: this is
+a pure optimization, never a correctness risk for the calls it declines to
+touch.
+"""
+
+import dis
+import types
+import typing as t
+
+from spasm._core import Bytecode
+from spasm._core import Instr
+from spasm._core import Label
+from spasm.bytecode import CO_ASYNC_GENERATOR
+from spasm.bytecode import CO_COROUTINE
+from spasm.bytecode import CO_GENERATOR
+from spasm.bytecode import CO_VARARGS
+from spasm.bytecode import CO_VARKEYWORDS
+from spasm.bytecode import PY311
+from spasm.bytecode import PY312
+from spasm.bytecode import decode_name_arg
+from spasm.bytecode import encode_name_arg
+from spasm.bytecode import is_name_op
+
+__all__ = ["inline"]
+
+_F = t.TypeVar("_F", bound=t.Callable[..., t.Any])
+
+# Instructions allowed in the "push arguments" run between the callable load
+# and the call itself: single-value, side-effect-free pushes only. A nested
+# call, attribute access or jump in there takes the call site out of scope.
+_SIMPLE_ARG_OPS = frozenset(
+    name for name in ("LOAD_FAST", "LOAD_CONST", "LOAD_FAST_CHECK", "LOAD_FAST_BORROW") if name in dis.opmap
+)
+
+_HASLOCAL = frozenset(dis.haslocal)
+
+# 3.13+ fuses two adjacent local accesses into one instruction whose oparg
+# packs both varname indices as (idx1 << 4) | idx2 (see CPython's
+# compile.c). from_code() doesn't unpack that, so it's decoded here and
+# split back into the two plain instructions it came from.
+_PAIRED_LOCAL_OPS = {
+    name: pair
+    for name, pair in (
+        ("LOAD_FAST_LOAD_FAST", ("LOAD_FAST", "LOAD_FAST")),
+        ("STORE_FAST_LOAD_FAST", ("STORE_FAST", "LOAD_FAST")),
+        ("STORE_FAST_STORE_FAST", ("STORE_FAST", "STORE_FAST")),
+    )
+    if name in dis.opmap
+}
+
+# LOAD_FAST_AND_CLEAR (comprehension-only) doesn't fit the abstraction model
+# either and has no simple unpacking; a callee containing one is left alone.
+_DISALLOWED_CALLEE_OPNAMES = frozenset(name for name in ("LOAD_FAST_AND_CLEAR",) if name in dis.opmap)
+
+_INELIGIBLE_CALLEE_FLAGS = CO_GENERATOR | CO_COROUTINE | CO_ASYNC_GENERATOR | CO_VARARGS | CO_VARKEYWORDS
+
+# The call-site terminator: the opcode(s) that must immediately follow the
+# argument-push run, each carrying the positional argument count as its arg.
+if PY312:
+    _CALL_TERMINATOR: tuple[str, ...] = ("CALL",)
+elif PY311:
+    _CALL_TERMINATOR = ("PRECALL", "CALL")
+else:
+    _CALL_TERMINATOR = ("CALL_FUNCTION",)
+
+
+class _CallSite(t.NamedTuple):
+    start: int  # index of the LOAD_GLOBAL loading the callable
+    end: int  # one past the last terminator instruction
+    name: str
+    argcount: int  # number of positional values pushed
+    arg_instr_count: int  # number of instructions doing the pushing (<= argcount)
+
+
+def _decode_global(names: t.Sequence[str], instr: Instr) -> tuple[str, bool] | None:
+    if dis.opname[instr.op] != "LOAD_GLOBAL":
+        return None
+    return decode_name_arg(names, "LOAD_GLOBAL", instr.arg)
+
+
+def _match_call_site(instrs: list[Instr], names: t.Sequence[str], start: int) -> _CallSite | None:
+    decoded = _decode_global(names, instrs[start])
+    if decoded is None:
+        return None
+    name, has_null = decoded
+    if PY311 and not has_null:
+        # A plain global load, not the callable position of a call.
+        return None
+
+    idx = start + 1
+    argcount = 0
+    while idx < len(instrs) and dis.opname[instrs[idx].op] != _CALL_TERMINATOR[0]:
+        instr = instrs[idx]
+        op_name = dis.opname[instr.op]
+        if instr.labels:
+            return None
+        if op_name in _SIMPLE_ARG_OPS:
+            argcount += 1
+        elif op_name == "LOAD_FAST_LOAD_FAST":
+            # Pure double-push, no side effect — safe in an arg-push run.
+            argcount += 2
+        else:
+            return None
+        idx += 1
+
+    if idx >= len(instrs):
+        return None
+
+    arg_instr_count = idx - (start + 1)
+    end = idx
+    for term_name in _CALL_TERMINATOR:
+        if end >= len(instrs):
+            return None
+        instr = instrs[end]
+        if dis.opname[instr.op] != term_name or instr.arg != argcount or instr.labels:
+            return None
+        end += 1
+
+    return _CallSite(start=start, end=end, name=name, argcount=argcount, arg_instr_count=arg_instr_count)
+
+
+def _find_call_sites(bc: Bytecode) -> list[_CallSite]:
+    sites = []
+    instrs = bc.instrs
+    i = 0
+    while i < len(instrs):
+        if dis.opname[instrs[i].op] == "LOAD_GLOBAL":
+            site = _match_call_site(instrs, bc.names, i)
+            if site is not None:
+                sites.append(site)
+                i = site.end
+                continue
+        i += 1
+    return sites
+
+
+def _resolve_global(func: types.FunctionType, name: str) -> t.Any:
+    globals_ = func.__globals__
+    if name in globals_:
+        return globals_[name]
+    builtins_ = globals_.get("__builtins__")
+    if isinstance(builtins_, dict):
+        return builtins_.get(name)
+    return getattr(builtins_, name, None)
+
+
+def _eligible_callee(callee: t.Any, caller: types.FunctionType, argcount: int) -> types.CodeType | None:
+    if not isinstance(callee, types.FunctionType) or callee.__code__ is caller.__code__:
+        return None
+
+    code = callee.__code__
+    if code.co_flags & _INELIGIBLE_CALLEE_FLAGS:
+        return None
+    if code.co_kwonlyargcount or code.co_argcount != argcount:
+        return None
+    if code.co_freevars or code.co_cellvars:
+        return None
+
+    return code
+
+
+def _arg_push_sources(arg_instrs: list[Instr], argcount: int) -> list[Instr | None]:
+    """Map each pushed-argument slot to the single instruction that pushes it.
+
+    ``None`` for a slot means it's one half of a fused ``LOAD_FAST_LOAD_FAST``
+    push: two values from one instruction, so there's no single instruction
+    to duplicate for that slot alone.
+    """
+    sources: list[Instr | None] = [None] * argcount
+    slot = 0
+    for instr in arg_instrs:
+        if dis.opname[instr.op] == "LOAD_FAST_LOAD_FAST":
+            slot += 2
+        else:
+            sources[slot] = instr
+            slot += 1
+    return sources
+
+
+def _reassigned_params(callee_bc: Bytecode, argcount: int) -> list[bool]:
+    """Which of the callee's first ``argcount`` locals are ever written to.
+
+    A parameter that's never reassigned can have its reads replaced by a
+    fresh copy of whatever pushed it in the caller, instead of round-tripping
+    through a dedicated ``STORE_FAST``/``LOAD_FAST`` pair.
+    """
+    name_to_index = {callee_bc.varnames[i]: i for i in range(argcount)}
+    reassigned = [False] * argcount
+
+    for instr in callee_bc.instrs:
+        op_name = dis.opname[instr.op]
+        if op_name in ("STORE_FAST", "DELETE_FAST"):
+            idx = name_to_index.get(instr.arg)
+            if idx is not None:
+                reassigned[idx] = True
+        elif op_name in _PAIRED_LOCAL_OPS:
+            op1, op2 = _PAIRED_LOCAL_OPS[op_name]
+            idx1, idx2 = instr.arg >> 4, instr.arg & 0xF
+            if op1 == "STORE_FAST" and idx1 < argcount:
+                reassigned[idx1] = True
+            if op2 == "STORE_FAST" and idx2 < argcount:
+                reassigned[idx2] = True
+
+    return reassigned
+
+
+def _splice(
+    caller_bc: Bytecode,
+    callee_code: types.CodeType,
+    call_site: _CallSite,
+    splice_id: int,
+    arg_instrs: list[Instr],
+) -> tuple[list[Instr], list[Instr], Label] | None:
+    callee_bc = Bytecode.from_code(callee_code)
+    if callee_bc.exc_entries:
+        return None
+    if any(dis.opname[instr.op] in _DISALLOWED_CALLEE_OPNAMES for instr in callee_bc.instrs):
+        return None
+
+    argcount = call_site.argcount
+    varname_map = {name: f"__inline_{splice_id}_{name}" for name in callee_bc.varnames}
+    end_label = caller_bc.new_label()
+    label_map: dict[Label, Label] = dict.fromkeys(callee_bc.end_labels, end_label)
+
+    def mapped_label(label: Label) -> Label:
+        if label not in label_map:
+            label_map[label] = caller_bc.new_label()
+        return label_map[label]
+
+    # A parameter that's read-only in the callee and pushed by a single,
+    # side-effect-free instruction in the caller doesn't need a dedicated
+    # local at all: every read of it is replaced by a fresh copy of that
+    # push, and the push/store pair that would otherwise ferry it through a
+    # local is dropped entirely.
+    arg_sources = _arg_push_sources(arg_instrs, argcount)
+    reassigned = _reassigned_params(callee_bc, argcount)
+    propagate = [arg_sources[i] is not None and not reassigned[i] for i in range(argcount)]
+    name_to_index = {callee_bc.varnames[i]: i for i in range(argcount)}
+
+    def local_read(op_name: str, idx: int, lineno: int) -> Instr:
+        source = arg_sources[idx] if idx < argcount else None
+        if op_name.startswith("LOAD_FAST") and source is not None and not reassigned[idx]:
+            return Instr(dis.opname[source.op], source.arg, lineno=lineno)
+        return Instr(op_name, varname_map[callee_bc.varnames[idx]], lineno=lineno)
+
+    kept_arg_instrs: list[Instr] = []
+    slot = 0
+    for instr in arg_instrs:
+        if dis.opname[instr.op] == "LOAD_FAST_LOAD_FAST":
+            kept_arg_instrs.append(instr)
+            slot += 2
+        else:
+            if not propagate[slot]:
+                kept_arg_instrs.append(instr)
+            slot += 1
+
+    lineno = caller_bc.instrs[call_site.end - 1].lineno
+
+    spliced: list[Instr] = [
+        Instr("STORE_FAST", varname_map[callee_bc.varnames[i]], lineno=lineno)
+        for i in range(argcount - 1, -1, -1)
+        if not propagate[i]
+    ]
+
+    # RESUME only makes sense as the very first instruction of a code
+    # object (frame setup); the caller already executed its own. Drop it,
+    # carrying forward any label pointing at it onto the next instruction.
+    pending_labels: list[Label] = []
+
+    for instr in callee_bc.instrs:
+        op_name = dis.opname[instr.op]
+        new_labels = pending_labels + [mapped_label(label) for label in instr.labels]
+        pending_labels = []
+
+        if op_name == "RESUME":
+            pending_labels = new_labels
+            continue
+
+        if op_name in _PAIRED_LOCAL_OPS:
+            op1, op2 = _PAIRED_LOCAL_OPS[op_name]
+            idx1, idx2 = instr.arg >> 4, instr.arg & 0xF
+            new = [
+                local_read(op1, idx1, instr.lineno),
+                local_read(op2, idx2, instr.lineno),
+            ]
+            new[0].labels = new_labels
+            spliced.extend(new)
+            continue
+
+        if op_name == "RETURN_CONST":
+            # RETURN_CONST pushes-and-returns a constant in one instruction
+            # (3.12+); splitting it back into the push and the jump it
+            # stands in for needs two.
+            new = [
+                Instr("LOAD_CONST", instr.arg, lineno=instr.lineno),
+                Instr("JUMP_FORWARD", end_label, lineno=instr.lineno),
+            ]
+            new[0].labels = new_labels
+            spliced.extend(new)
+            continue
+
+        if op_name == "RETURN_VALUE":
+            new_instr = Instr("JUMP_FORWARD", end_label, lineno=instr.lineno)
+        elif instr.op in _HASLOCAL:
+            idx = name_to_index.get(instr.arg)
+            if idx is not None:
+                new_instr = local_read(op_name, idx, instr.lineno)
+            else:
+                new_instr = Instr(op_name, varname_map[instr.arg], lineno=instr.lineno)
+        elif is_name_op(instr.op):
+            name, flag = decode_name_arg(callee_bc.names, op_name, instr.arg)
+            new_instr = Instr(op_name, encode_name_arg(caller_bc, op_name, name, flag=flag), lineno=instr.lineno)
+        elif isinstance(instr.arg, Label):
+            new_instr = Instr(op_name, mapped_label(instr.arg), lineno=instr.lineno)
+        else:
+            new_instr = Instr(op_name, instr.arg, lineno=instr.lineno)
+
+        new_instr.labels = new_labels
+        spliced.append(new_instr)
+
+    return kept_arg_instrs, spliced, end_label
+
+
+def inline(func: _F) -> _F:
+    """Splice safe, module-level calls made by ``func`` in place of the call.
+
+    Only calls resolved via ``LOAD_GLOBAL`` with a fixed number of simple
+    positional arguments are considered; calls this can't prove safe (kwargs,
+    starred args, method/attribute calls, generator or closure callees,
+    recursive calls, ...) are left exactly as they were.
+    """
+    code = func.__code__
+    bc = Bytecode.from_code(code)
+    sites = {site.start: site for site in _find_call_sites(bc)}
+    if not sites:
+        return func
+
+    instrs = bc.instrs
+    new_instrs: list[Instr] = []
+    pending_labels: list[Label] = []
+    splice_id = 0
+    changed = False
+    func_ = t.cast("types.FunctionType", func)
+
+    i = 0
+    while i < len(instrs):
+        site = sites.get(i)
+        result = None
+        if site is not None:
+            callee_code = _eligible_callee(_resolve_global(func_, site.name), func_, site.argcount)
+            if callee_code is not None:
+                arg_instrs = instrs[site.start + 1 : site.start + 1 + site.arg_instr_count]
+                result = _splice(bc, callee_code, site, splice_id, arg_instrs)
+
+        if site is None or result is None:
+            instr = instrs[i]
+            if pending_labels:
+                instr.labels = pending_labels + list(instr.labels)
+                pending_labels = []
+            new_instrs.append(instr)
+            i += 1
+            continue
+
+        kept_arg_instrs, spliced, end_label = result
+        splice_id += 1
+        changed = True
+
+        # The original argument-push instructions (between the LOAD_GLOBAL
+        # and the CALL terminator) are kept as-is where their value still
+        # needs to reach a local: they compute and push the values the
+        # callee's STORE_FASTs below consume. Pushes that _splice inlined
+        # directly at their use site instead are dropped here. Either way,
+        # the LOAD_GLOBAL and the CALL/PRECALL/CALL_FUNCTION terminator
+        # itself are always dropped.
+        head = kept_arg_instrs[0] if kept_arg_instrs else spliced[0]
+        head.labels = pending_labels + list(instrs[site.start].labels) + head.labels
+        pending_labels = [end_label]
+
+        new_instrs.extend(kept_arg_instrs)
+        new_instrs.extend(spliced)
+        i = site.end
+
+    if not changed:
+        return func
+
+    if pending_labels:
+        bc.end_labels = pending_labels + bc.end_labels
+
+    bc.instrs = new_instrs
+    func.__code__ = bc.to_code()  # type: ignore[misc]
+    return func

--- a/spasm/inliner.py
+++ b/spasm/inliner.py
@@ -37,8 +37,12 @@ _F = t.TypeVar("_F", bound=t.Callable[..., t.Any])
 # Instructions allowed in the "push arguments" run between the callable load
 # and the call itself: single-value, side-effect-free pushes only. A nested
 # call, attribute access or jump in there takes the call site out of scope.
+# LOAD_SMALL_INT (3.14+) is how small integer constants are pushed instead of
+# LOAD_CONST.
 _SIMPLE_ARG_OPS = frozenset(
-    name for name in ("LOAD_FAST", "LOAD_CONST", "LOAD_FAST_CHECK", "LOAD_FAST_BORROW") if name in dis.opmap
+    name
+    for name in ("LOAD_FAST", "LOAD_CONST", "LOAD_FAST_CHECK", "LOAD_FAST_BORROW", "LOAD_SMALL_INT")
+    if name in dis.opmap
 )
 
 _HASLOCAL = frozenset(dis.haslocal)
@@ -47,15 +51,24 @@ _HASLOCAL = frozenset(dis.haslocal)
 # packs both varname indices as (idx1 << 4) | idx2 (see CPython's
 # compile.c). from_code() doesn't unpack that, so it's decoded here and
 # split back into the two plain instructions it came from.
+# LOAD_FAST_BORROW_LOAD_FAST_BORROW is 3.14's borrowed-reference variant of
+# LOAD_FAST_LOAD_FAST, encoded the same way.
 _PAIRED_LOCAL_OPS = {
     name: pair
     for name, pair in (
         ("LOAD_FAST_LOAD_FAST", ("LOAD_FAST", "LOAD_FAST")),
+        ("LOAD_FAST_BORROW_LOAD_FAST_BORROW", ("LOAD_FAST_BORROW", "LOAD_FAST_BORROW")),
         ("STORE_FAST_LOAD_FAST", ("STORE_FAST", "LOAD_FAST")),
         ("STORE_FAST_STORE_FAST", ("STORE_FAST", "STORE_FAST")),
     )
     if name in dis.opmap
 }
+
+# The subset of _PAIRED_LOCAL_OPS that are pure double-loads, safe to appear
+# in an argument-push run the same way LOAD_FAST_LOAD_FAST is.
+_PAIRED_ARG_PUSH_OPS = frozenset(
+    name for name, (op1, op2) in _PAIRED_LOCAL_OPS.items() if op1.startswith("LOAD") and op2.startswith("LOAD")
+)
 
 # LOAD_FAST_AND_CLEAR (comprehension-only) doesn't fit the abstraction model
 # either and has no simple unpacking; a callee containing one is left alone.
@@ -105,7 +118,7 @@ def _match_call_site(instrs: list[Instr], names: t.Sequence[str], start: int) ->
             return None
         if op_name in _SIMPLE_ARG_OPS:
             argcount += 1
-        elif op_name == "LOAD_FAST_LOAD_FAST":
+        elif op_name in _PAIRED_ARG_PUSH_OPS:
             # Pure double-push, no side effect — safe in an arg-push run.
             argcount += 2
         else:
@@ -178,7 +191,7 @@ def _arg_push_sources(arg_instrs: list[Instr], argcount: int) -> list[Instr | No
     sources: list[Instr | None] = [None] * argcount
     slot = 0
     for instr in arg_instrs:
-        if dis.opname[instr.op] == "LOAD_FAST_LOAD_FAST":
+        if dis.opname[instr.op] in _PAIRED_ARG_PUSH_OPS:
             slot += 2
         else:
             sources[slot] = instr
@@ -255,7 +268,7 @@ def _splice(
     kept_arg_instrs: list[Instr] = []
     slot = 0
     for instr in arg_instrs:
-        if dis.opname[instr.op] == "LOAD_FAST_LOAD_FAST":
+        if dis.opname[instr.op] in _PAIRED_ARG_PUSH_OPS:
             kept_arg_instrs.append(instr)
             slot += 2
         else:

--- a/tests/test_asm.py
+++ b/tests/test_asm.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 
 from spasm import Assembly
-from spasm.asm import SpasmParseError
+from spasm._asm import SpasmParseError
 from spasm.bytecode import CO_NESTED
 
 PY = sys.version_info[:2]

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,85 @@
+import sys
+
+import pytest
+
+import spasm
+
+PY = sys.version_info[:2]
+
+
+def test_asm_bind_args():
+    @spasm.asm(retval=42)
+    def answer():
+        """
+        load_const {retval}
+        return_value
+        """
+
+    assert answer() == 42
+
+
+def test_asm_uses_real_signature_for_arguments():
+    if PY >= (3, 11):
+
+        @spasm.asm()
+        def add(x, y):
+            """
+            resume 0
+            load_fast $x
+            load_fast $y
+            binary_op 0
+            return_value
+            """
+    else:
+
+        @spasm.asm()
+        def add(x, y):
+            """
+            load_fast $x
+            load_fast $y
+            binary_add
+            return_value
+            """
+
+    assert add(3, 4) == 7
+
+
+def test_asm_clears_docstring():
+    @spasm.asm(retval=1)
+    def one():
+        """
+        load_const {retval}
+        return_value
+        """
+
+    assert one.__doc__ is None
+
+
+def test_asm_requires_docstring():
+    with pytest.raises(ValueError, match="docstring"):
+
+        @spasm.asm()
+        def no_doc():
+            pass
+
+
+def test_asm_rejects_varargs():
+    with pytest.raises(ValueError, match=r"\*args"):
+
+        @spasm.asm()
+        def varargs(*args):
+            """
+            load_const None
+            return_value
+            """
+
+
+def test_asm_rejects_kwonly():
+    with pytest.raises(ValueError, match="keyword-only"):
+
+        @spasm.asm()
+        def kwonly(*, x):
+            """
+            load_const None
+            return_value
+            """

--- a/tests/test_inliner.py
+++ b/tests/test_inliner.py
@@ -1,0 +1,193 @@
+import dis
+
+import spasm
+
+# Callees have to live at module scope: a callee defined inside a test
+# function would be a closure over that function (LOAD_DEREF), not a global
+# (LOAD_GLOBAL) — and the inliner only handles LOAD_GLOBAL-resolved calls.
+
+
+def add_one(x):
+    return x + 1
+
+
+def add(a, b):
+    return a + b
+
+
+def double(x):
+    return x * 2
+
+
+def sign(x):
+    if x > 0:
+        return 1
+    return -1
+
+
+def add_kwarg(a, b=1):
+    return a + b
+
+
+def total(*args):
+    return sum(args)
+
+
+def gen(x):
+    yield x
+
+
+def bump(x):
+    x = x + 1
+    return x * 2
+
+
+def double_use(a, b):
+    return a + a + b
+
+
+def _has_call(func: object) -> bool:
+    return any(instr.opname.startswith("CALL") or instr.opname == "PRECALL" for instr in dis.get_instructions(func))
+
+
+def test_inline_single_arg_call() -> None:
+    @spasm.inline
+    def compute(n):
+        return add_one(n) * 2
+
+    assert [compute(n) for n in (0, 1, -3, 10)] == [2, 4, -4, 22]
+    assert not _has_call(compute)
+
+
+def test_inline_two_arg_call() -> None:
+    @spasm.inline
+    def compute(x, y):
+        return add(x, y) + add(y, x)
+
+    assert compute(3, 4) == 14
+    assert not _has_call(compute)
+
+
+def test_inline_call_with_const_argument() -> None:
+    @spasm.inline
+    def compute(x):
+        return add(x, 10)
+
+    assert compute(3) == 13
+    assert not _has_call(compute)
+
+
+def test_inline_multiple_call_sites() -> None:
+    @spasm.inline
+    def compute(a, b):
+        return double(a) + double(b)
+
+    assert compute(3, 4) == 14
+    assert not _has_call(compute)
+
+
+def test_inline_callee_with_multiple_returns() -> None:
+    @spasm.inline
+    def compute(x):
+        return sign(x) + 1
+
+    assert compute(5) == 2
+    assert compute(-5) == 0
+    assert not _has_call(compute)
+
+
+def test_inline_no_call_sites_returns_unchanged() -> None:
+    @spasm.inline
+    def plain(x):
+        return x + 1
+
+    assert plain(4) == 5
+
+
+def test_inline_leaves_kwarg_call_untouched() -> None:
+    @spasm.inline
+    def compute(x):
+        return add_kwarg(x, b=2)
+
+    assert compute(5) == 7
+
+
+def test_inline_leaves_varargs_callee_untouched() -> None:
+    @spasm.inline
+    def compute(x):
+        return total(x, x)
+
+    assert compute(3) == 6
+
+
+def test_inline_leaves_generator_callee_untouched() -> None:
+    @spasm.inline
+    def compute(x):
+        return list(gen(x))
+
+    assert compute(5) == [5]
+
+
+def test_inline_leaves_recursive_call_untouched() -> None:
+    @spasm.inline
+    def fact(n):
+        if n <= 1:
+            return 1
+        return n * fact(n - 1)
+
+    assert fact(5) == 120
+
+
+def test_inline_propagates_readonly_simple_args() -> None:
+    @spasm.inline
+    def compute(n):
+        return add_one(n) * 2
+
+    assert [compute(n) for n in (0, 1, -3, 10)] == [2, 4, -4, 22]
+    assert not _has_call(compute)
+    # `x` is read-only in add_one and pushed by a plain LOAD_FAST, so it's
+    # substituted at its use site instead of round-tripping through a
+    # dedicated local.
+    assert "__inline_0_x" not in compute.__code__.co_varnames
+
+
+def test_inline_keeps_local_for_reassigned_param() -> None:
+    @spasm.inline
+    def compute(n):
+        return bump(n)
+
+    assert [compute(n) for n in (0, 1, -3, 10)] == [2, 4, -4, 22]
+    assert not _has_call(compute)
+    # `x` is reassigned inside bump, so it still needs its own local.
+    assert "__inline_0_x" in compute.__code__.co_varnames
+
+
+def test_inline_propagates_arg_used_multiple_times() -> None:
+    @spasm.inline
+    def compute(x):
+        # A const second argument keeps the compiler from fusing the two
+        # pushes into a single LOAD_FAST_LOAD_FAST, so both slots remain
+        # eligible for propagation.
+        return double_use(x, 10)
+
+    assert compute(3) == 16
+    assert compute(-2) == 6
+    assert not _has_call(compute)
+    assert "__inline_0_a" not in compute.__code__.co_varnames
+    assert "__inline_0_b" not in compute.__code__.co_varnames
+
+
+def test_inline_leaves_closure_callee_untouched() -> None:
+    def make_adder(n):
+        def adder(x):
+            return x + n
+
+        return adder
+
+    add_five = make_adder(5)
+
+    @spasm.inline
+    def compute(x):
+        return add_five(x)
+
+    assert compute(3) == 8

--- a/tests/test_spasm.py
+++ b/tests/test_spasm.py
@@ -2,7 +2,7 @@ import pytest
 
 from spasm.__main__ import SpasmUnmarshalError
 from spasm.__main__ import spasm
-from spasm.asm import SpasmParseError
+from spasm._asm import SpasmParseError
 
 
 def test_spasm_unmarshallable(tmp_path):


### PR DESCRIPTION
Add spasm.asm, a decorator that compiles a function's docstring as spasm assembly and replaces its __code__ with the result -- for the cases where only one function needs to drop to bytecode and the rest of a module stays ordinary Python. The decorator's own keyword arguments are compile-time Assembly.compile() bind-args, distinct from the function's own runtime parameters (which come from its signature, as normal).

Add spasm.inline, a decorator applied to a caller that splices eligible module-level function calls directly into its bytecode, removing call overhead for calls it can prove safe to inline. A read-only parameter pushed by a single caller instruction is substituted at its use sites instead of round-tripping through a dedicated local.

Renames spasm/asm.py to the private spasm/_asm.py now that Assembly is re-exported from spasm/__init__.py, so spasm.asm is free to become the decorator's public name instead of the module's.